### PR TITLE
rysncd feature additions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ Requirements
 
 Attributes
 ==========
+* default[:rsync][:daemon] = "false"
+* default[:rsync][:rsyncd_conf] = "/etc/rsyncd.conf"
+* default[:rsync][:rsyncd_opts] = ""
+* default[:rsync][:rsynd_nice] = ""
+
+Set the node[:rsync][:daemon] = "true" to enable the rsync daemon.
+Other parameters are all default settings for rsync.  Please see
+/etc/defaults/rsync for details on each setting.
 
 Recipes
 =======
+* default.rb
+
 
 default
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,4 @@
+default[:rsync][:daemon] = "false"
+default[:rsync][:rsyncd_conf] = "/etc/rsyncd.conf"
+default[:rsync][:rsyncd_opts] = ""
+default[:rsync][:rsynd_nice] = ""

--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -1,0 +1,4 @@
+default[:rsync][:daemon] = "false"
+default[:rsync][:rsyncd_conf] = "/etc/rsyncd.conf"
+default[:rsync][:rsyncd_opts] = ""
+default[:rsync][:rsynd_nice] = ""

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,52 @@
+{
+  "license": "Apache 2.0",
+  "recipes": {
+    "rsync": ""
+  },
+  "conflicting": {
+
+  },
+  "dependencies": {
+
+  },
+  "providing": {
+    "rsync": [
+
+    ]
+  },
+  "long_description": "",
+  "description": "Installs rsync",
+  "replacing": {
+
+  },
+  "platforms": {
+    "debian": [
+
+    ],
+    "fedora": [
+
+    ],
+    "centos": [
+
+    ],
+    "ubuntu": [
+
+    ],
+    "redhat": [
+
+    ]
+  },
+  "version": "0.7.0",
+  "maintainer": "Opscode, Inc.",
+  "recommendations": {
+
+  },
+  "name": "rsync",
+  "maintainer_email": "cookbooks@opscode.com",
+  "attributes": {
+
+  },
+  "suggestions": {
+
+  }
+}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,3 +18,22 @@
 #
 
 package "rsync"
+
+template "#{node[:rsync][:rsyncd_conf]}" do
+  source "rsync_default.erb"
+  owner "root"
+  group "root"
+  mode 644
+  variables(
+    :daemon => node[:rsync][:daemon],
+    :rsyncd_conf => node[:rsync][:rsyncd_conf],
+    :rsyncd_opts => node[:rsync][:rsyncd_opts],
+    :rsync_nice => node[:rsync][:rsync_nice]
+  )
+end
+
+if node[:rsync][:daemon] == "true"
+  service "rsync" do
+    action [:enable, :start]
+  end
+end

--- a/templates/default/rsync_default.erb
+++ b/templates/default/rsync_default.erb
@@ -1,0 +1,41 @@
+# defaults file for rsync daemon mode
+
+# start rsync in daemon mode from init.d script?
+#  only allowed values are "true", "false", and "inetd"
+#  Use "inetd" if you want to start the rsyncd from inetd,
+#  all this does is prevent the init.d script from printing a message
+#  about not starting rsyncd (you still need to modify inetd's config yourself).
+RSYNC_ENABLE=<%= @daemon %>
+
+# which file should be used as the configuration file for rsync.
+# This file is used instead of the default /etc/rsyncd.conf
+# Warning: This option has no effect if the daemon is accessed
+#          using a remote shell. When using a different file for
+#          rsync you might want to symlink /etc/rsyncd.conf to
+#          that file.
+RSYNC_CONFIG_FILE=<%= @rsyncd_conf %>
+
+# what extra options to give rsync --daemon?
+#  that excludes the --daemon; that's always done in the init.d script
+#  Possibilities are:
+#   --address=123.45.67.89    (bind to a specific IP address)
+#   --port=8730       (bind to specified port; default 873)
+RSYNC_OPTS='<%= @rsync_opts %>'
+
+# run rsyncd at a nice level?
+#  the rsync daemon can impact performance due to much I/O and CPU usage,
+#  so you may want to run it at a nicer priority than the default priority.
+#  Allowed values are 0 - 19 inclusive; 10 is a reasonable value.
+RSYNC_NICE='<%= @rsync_nice %>'
+
+# run rsyncd with ionice?
+#  "ionice" does for IO load what "nice" does for CPU load.
+#  As rsync is often used for backups which aren't all that time-critical,
+#  reducing the rsync IO priority will benefit the rest of the system.
+#  See the manpage for ionice for allowed options.
+#  -c3 is recommended, this will run rsync IO at "idle" priority. Uncomment
+#  the next line to activate this.
+# RSYNC_IONICE='-c3'
+
+# Don't forget to create an appropriate config file,
+# else the daemon will not start.


### PR DESCRIPTION
addition of rsyncd defaults and ability to run on rsync daemon, rsyncd.conf is not provided as it must be unique to each use
