### PR TITLE
Add chkconfig support to init script

### DIFF
--- a/templates/default/rsync-init.erb
+++ b/templates/default/rsync-init.erb
@@ -2,6 +2,9 @@
 #
 # Rsyncd init script
 #
+# chkconfig: 2345 98 02
+# description: Remote file copy program daemon
+#
 # Source function library.
 . /etc/init.d/functions
 . /etc/sysconfig/network


### PR DESCRIPTION
service['rsyncd'] failed with

```
STDERR: service rsyncd does not support chkconfig
```

Add suitable decorations to the init script so that chkconfig can handle
it.
