### PR TITLE
Allow "blank" values in generated rsyncd.conf

### DIFF
--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -28,7 +28,7 @@ def write_conf
       rsync_modules[resource.name] ||= Hash.new
       attr_keys.each do |key| 
         value = resource.send(key)
-        next if value.blank?
+        next if value.nil?
         rsync_modules[resource.name][snake_to_space(key)] = value 
       end
     end
@@ -36,7 +36,7 @@ def write_conf
 
   global_opts = Hash.new
   node['rsyncd']['globals'].each do |key, value|
-    next if value.blank?
+    next if value.nil?
     global_opts[snake_to_space(key)] = value
   end
 


### PR DESCRIPTION
When writing rsyncd.conf, the previous code skipped entries that
satisfied value.blank?, in order to avoid writing out unset attributes.
But this also affected values set to false where the built-in default of
rsync is true.  For example, it was impossible to configure an rsync
server with "read only = false".  Fix this by testing for nil? instead.
