### PR TITLE
Fixes to allow rsync daemon to be started if not up.

### DIFF
--- a/templates/default/rsync-init.erb
+++ b/templates/default/rsync-init.erb
@@ -59,7 +59,8 @@ restart)
   start
 ;;
 status)
-  status rsyncd
+  status rsync
+  exit $?
 ;;
 *)
   echo "Usage: rsyncd {start|stop|restart|status}"


### PR DESCRIPTION
I noticed, on the Red Hat family OS's, that when the rsync daemon is not running then the chef-client run will fail to start it despite there being a "service [:enable, :start]" present in the server cookbook. This is because in the "status" case statement of the Red Hat init script two things are going wrong
- The daemon process is called "rsync" not "rsyncd"
- The script does not exit with a non-zero exit code if the service is not running

I have fixed this by correcting the process name and exiting with the return code of the "status" function. It seems to now start the daemon if it is found to be down. I am in the process of creating a Jira ticket on the Opscode side of things.
