### PR TITLE
Supports Chef >12.4.1. Closes chef-cookbooks/rsync#18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ rsync Cookbook CHANGELOG
 ========================
 This file is used to list changes made in each version of the rsync cookbook.
 
+v0.8.9 (2015-09-30)
+-------------------
+- [#18] Support Chef > 12.4.1
+
 v0.8.8 (2015-05-07)
 -------------------
 - [#15] Add incoming/outgoing chmod options

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs rsync'
-version           '0.8.8'
+version           '0.8.9'
 
 recipe 'rsync::default', 'Installs rsync, Provides LWRP rsync_serve for serving paths via rsyncd'
 recipe 'rsync::server', 'Installs rsync and starts a service to serve a directory'

--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -137,12 +137,11 @@ def rsync_modules
       resource.action == :add ||
       resource.action.include?(:add)
     )
-      hash[resource.name] ||= {}
-      resource_attributes.each do |key|
-        value = resource.send(key)
-        next if value.nil?
-        hash[resource.name][attribute_to_directive(key)] = value
-      end
+    hash[resource.name] ||= {}
+    resource_attributes.each do |key|
+      value = resource.send(key)
+      next if value.nil?
+      hash[resource.name][attribute_to_directive(key)] = value
     end
   end
 end

--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -133,12 +133,16 @@ end
 # @return [Hash]
 def rsync_modules
   rsync_resources.each_with_object({}) do |resource, hash|
-    skip unless resource.config_path == new_resource.config_path && resource.action == :add
-    hash[resource.name] ||= {}
-    resource_attributes.each do |key|
-      value = resource.send(key)
-      next if value.nil?
-      hash[resource.name][attribute_to_directive(key)] = value
+    skip unless resource.config_path == new_resource.config_path && (
+      resource.action == :add ||
+      resource.action.include?(:add)
+    )
+      hash[resource.name] ||= {}
+      resource_attributes.each do |key|
+        value = resource.send(key)
+        next if value.nil?
+        hash[resource.name][attribute_to_directive(key)] = value
+      end
     end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'rsync::default' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04').converge('rsync::default')
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge('rsync::default')
   end
 
   it 'installs the rsync package' do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -8,7 +8,7 @@ describe 'rsync::server' do
 
   context 'on rhel' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'redhat', version: '6.3').converge('rsync::server')
+      ChefSpec::SoloRunner.new(platform: 'redhat', version: '6.3').converge('rsync::server')
     end
 
     it 'includes the default recipe' do
@@ -39,7 +39,7 @@ describe 'rsync::server' do
 
   context 'on debian' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04').converge('rsync::server')
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge('rsync::server')
     end
 
     it 'includes the default recipe' do


### PR DESCRIPTION
With Chef 12.4.1, resource.action returns an array instead of a simple value.
This commit aims to keep historical behaviour for pre 12.4.1 Chef versions, while supporting post 12.4.1 one.