### PR TITLE
Fix chef 13 compatibility

### DIFF
--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -20,6 +20,8 @@
 # we are not using inline resources on purpose here as it breaks
 # the accumulator pattern this cookbook implements
 
+use_inline_resources
+
 action :add do # ~FC017
   write_conf
 end
@@ -33,7 +35,7 @@ end
 # Build and write the config template
 #
 def write_conf
-  t = template(new_resource.config_path) do
+  template(new_resource.config_path) do
     source   'rsyncd.conf.erb'
     cookbook 'rsync'
     owner    'root'
@@ -45,8 +47,6 @@ def write_conf
     )
     notifies :restart, "service[#{node['rsyncd']['service']}]", :delayed
   end
-
-  new_resource.updated_by_last_action(t.updated?)
 
   service node['rsyncd']['service'] do
     action :nothing
@@ -99,8 +99,8 @@ end
 #
 # @return [Array<Chef::Resource>]
 def rsync_resources
-  run_context.resource_collection.select do |resource|
-    resource.is_a?(Chef::Resource::RsyncServe)
+  ::ObjectSpace.each_object(::Chef::Resource).select do |resource|
+    resource.resource_name == :rsync_serve
   end
 end
 


### PR DESCRIPTION


### Description
Since the chef 13 upgrade the cookbook does not work anymore: since the introduction of the `custom_resource` the access of the run_context is not global.

### Issues Resolved
So we could use `::Chef.node.run_context.resource_collection.all_resources` in order to
selection the right resource but using `::ObjectSpace.each_object(::Chef::Resource)` guaranty that we get all the resources define as a 'rsync_serve' resource.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
