### PR TITLE
Add Amazon linux compatibility for init script.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -27,6 +27,14 @@ when 'rhel'
     group  'root'
     mode   '0755'
   end
+when 'amazon'
+  # RedHat does not provide an init script for rsyncd
+  template '/etc/init.d/rsyncd' do
+    source 'rsync-init.erb'
+    owner  'root'
+    group  'root'
+    mode   '0755'
+  end
 when 'debian'
   template '/etc/default/rsync' do
     source 'rsync-defaults.erb'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,15 +19,7 @@
 include_recipe 'rsync::default'
 
 case node['platform_family']
-when 'rhel'
-  # RedHat does not provide an init script for rsyncd
-  template '/etc/init.d/rsyncd' do
-    source 'rsync-init.erb'
-    owner  'root'
-    group  'root'
-    mode   '0755'
-  end
-when 'amazon'
+when 'rhel', 'amazon'
   # RedHat does not provide an init script for rsyncd
   template '/etc/init.d/rsyncd' do
     source 'rsync-init.erb'

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -67,4 +67,34 @@ describe 'rsync::server' do
       expect(chef_run).to enable_service('rsync')
     end
   end
+  context 'on amazon' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'amazon', version: '2016.09').converge('rsync::server')
+    end
+
+    it 'includes the default recipe' do
+      expect(chef_run).to include_recipe('rsync::default')
+    end
+
+    context '/etc/init.d/rsyncd template' do
+      let(:template) { chef_run.template('/etc/init.d/rsyncd') }
+
+      it 'writes the template' do
+        expect(chef_run).to render_file('/etc/init.d/rsyncd').with_content('Rsyncd init script')
+      end
+
+      it 'is owned by root:root' do
+        expect(template.owner).to eq('root')
+        expect(template.group).to eq('root')
+      end
+
+      it 'has the correct permissions' do
+        expect(template.mode).to eq('0755')
+      end
+    end
+
+    it 'starts and enables the rsync service' do
+      expect(chef_run).to enable_service('rsyncd')
+    end
+  end
 end


### PR DESCRIPTION
From chef 13 Amazon linux has it's own platform family. The
server recipe needs to be able to handle this.

### Description

This change allows the cookbook to create and run rsyncd service on amazon linux instances. The platform_family now says 'amazon' for Amazon Linux in chef 13+. The server recipe needs to account for this.

Note the kitchen tests were failing before this pull request. Run `kitchen converge networking-amazonlinux` before and after my pull request to see this.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ /] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ /] New functionality includes testing.
- [ /] New functionality has been documented in the README if applicable
- [/ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
