### PR TITLE
Sort modules alphabetically to preserve idempotency across Chef runs

### DIFF
--- a/templates/default/rsyncd.conf.erb
+++ b/templates/default/rsyncd.conf.erb
@@ -6,7 +6,7 @@
 <% end -%>
 
 # Modules
-<% @modules.each_key do |mod| -%>
+<% @modules.keys.sort.each do |mod| -%>
 [<%= mod %>]
   <% @modules[mod].each do |key,value| -%>
     <%= key %> = <%= value %>

--- a/test/fixtures/cookbooks/test/recipes/simple.rb
+++ b/test/fixtures/cookbooks/test/recipes/simple.rb
@@ -2,6 +2,10 @@ apt_update 'update' if platform_family?('debian')
 
 include_recipe 'rsync::server'
 
+rsync_serve 'foo' do
+  path '/foo'
+end
+
 rsync_serve 'tmp' do
   path '/tmp'
 end

--- a/test/integration/simple/default_spec.rb
+++ b/test/integration/simple/default_spec.rb
@@ -6,8 +6,8 @@ describe command('ps aux | grep rsync') do
   its('exit_status') { should eq 0 }
 end
 
-# rsync is serving /tmp
+# rsync is serving /foo and /tmp alphabetically
 describe command('rsync rsync://127.0.0.1') do
-  its('stdout') { should match /tmp/ }
+  its('stdout') { should match /foo\s*\ntmp/ }
   its('exit_status') { should eq 0 }
 end


### PR DESCRIPTION
### Description

Modules are written in random order to `rsyncd.conf` across different Chef runs. This means the rsync daemon will get restarted on nearly every Chef runs when a dozen modules are defined. This is problematic since this aborts any ongoing transfer each time it happens. This commit makes sure we sort modules alphabetically before writing them to `rsyncd.conf` thus ensuring idempotency.

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
